### PR TITLE
Replace mapquest tiles with Stamen terrain.

### DIFF
--- a/source/javascripts/app/map.js
+++ b/source/javascripts/app/map.js
@@ -2,11 +2,11 @@ var southWest = L.latLng(34.9816, -85.4719);
 var northEast = L.latLng(35.217, -85.0462);
 var center = L.latLng(35.0657, -85.241);
 var bounds = L.latLngBounds(southWest, northEast);
-var tiles = '//otile1.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png';
+var tiles = '//tile.stamen.com/terrain/{z}/{x}/{y}.jpg';
 var geocoder = 'http://maps.hamiltontn.gov/ArcGIS/rest/services/Addressing_Locator/GeocodeServer/findAddressCandidates';
 var card_template = $('#card_template').html();
 var zone_name_template = $('#zone_name_template').html();
-var map_attribution = 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Zone data &copy; City of Chattanooga'; 
+var map_attribution = 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>. Zone data &copy; City of Chattanooga';
 var marker;
 var zones;
 


### PR DESCRIPTION
Fixes #5.
Stamen terrain: http://maps.stamen.com/terrain/#12/37.7706/-122.3782

What it looks like with CPD Zones: 
![cpdzones](https://cloud.githubusercontent.com/assets/42041/16906032/f5c1d5d4-4c7d-11e6-9190-4abacce3b6e2.png)

@aplannersguide This will need to be deployed after merged. I can do that as long as you're OK with that.
