### PR TITLE
Switch out geocoding service.

### DIFF
--- a/source/javascripts/app/map.js
+++ b/source/javascripts/app/map.js
@@ -3,7 +3,7 @@ var northEast = L.latLng(35.217, -85.0462);
 var center = L.latLng(35.0657, -85.241);
 var bounds = L.latLngBounds(southWest, northEast);
 var tiles = '//tile.stamen.com/terrain/{z}/{x}/{y}.jpg';
-var geocoder = 'http://pwgis.chattanooga.gov/arcgis/rest/services/Locators/ChattGeo/GeocodeServer/findAddressCandidates';
+var geocoder = 'https://pwgis.chattanooga.gov/arcgis/rest/services/Locators/ChattaData/GeocodeServer/findAddressCandidates';
 var card_template = $('#card_template').html();
 var zone_name_template = $('#zone_name_template').html();
 var map_attribution = 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, under <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>. Data by <a href="http://openstreetmap.org">OpenStreetMap</a>, under <a href="http://creativecommons.org/licenses/by-sa/3.0">CC BY SA</a>. Zone data &copy; City of Chattanooga';


### PR DESCRIPTION
Fixes #13.

Uses this service from the same server: https://pwgis.chattanooga.gov/arcgis/rest/services/Locators/ChattaData/GeocodeServer

@aplannersguide you should confirm that this is an OK service to use. It's provided by the same server previously. Not sure what the usage actually is, but don't want to surprise whoever is maintaining that pwgis server with a sudden spike in usage.