### PR TITLE
Bring ffi from 1.9.25 to 1.15.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GEM
     erubis (2.7.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
-    ffi (1.9.25)
+    ffi (1.15.4)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt


### PR DESCRIPTION
Middleman fails to compile application with ffi 1.9.25 on M1 Macs due to lack of support for 32-bit binaries. Upgrading to ffi 1.15.4 fixes the application.